### PR TITLE
EC2 terraform config

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -1,0 +1,49 @@
+resource "aws_security_group" "main" {
+  name        = "main"  
+  description = "Allow SSH traffic"
+  # allow ingress ("in") traffic on port 22, the port SSH runs on
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  # allow all egress ("out") traffic out to the internet
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_key_pair" "dawouds_ssh_key" {
+  key_name   = "dawouds_ssh_key"
+  public_key = file("~/.ssh/id_ed25519.pub")  # this path ~/.ssh/id_rsa.pub should point to a real file on your local/laptop
+}
+
+resource "aws_instance" "main" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+  availability_zone   = "us-east-1a"
+  key_name = aws_key_pair.dawouds_ssh_key.key_name
+  subnet_id = aws_subnet.public1.id
+  vpc_security_group_ids = [aws_security_group.main.id]
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,13 +1,7 @@
 resource "aws_security_group" "main" {
   name        = "main"  
   description = "Allow SSH traffic"
-  # allow ingress ("in") traffic on port 22, the port SSH runs on
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  
   # allow all egress ("out") traffic out to the internet
   egress {
     from_port   = 0

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,47 @@
+resource "aws_iam_instance_profile" "user1" {
+  name = "user1"
+  role = aws_iam_role.role.name
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "role" {
+  name               = "test_role"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+data "aws_iam_policy_document" "s3_read_write" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::<your s3 url bucket name>"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = ["arn:aws:s3:::<your s3 url bucket name>/*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+    ]
+    resources = ["arn:aws:s3:::<your s3 url bucket name>/*"]
+  }
+}

--- a/s3.tf
+++ b/s3.tf
@@ -1,0 +1,15 @@
+resource "aws_s3_bucket" "main" {
+  bucket = "dawoud-tf-test-bucket"
+
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "main" {
+  bucket = aws_s3_bucket.main.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -65,7 +65,7 @@ resource "aws_route_table" "public" {
   }
 
   tags = {
-    Name = "example"
+    Name = "main"
   }
 }
 


### PR DESCRIPTION
# Background
This PR adds terraform to automatically provision an EC2 instance that can be SSH’ed from my laptop.

# What does this PR do?
- Adds key pair, security group, and AWS EC2 instance resources
- We want to add these because eventually we will deploy an app on AWS, and that app will need to run on EC2 in some capacity (either directly on EC2 or with ECS)

# How was this tested?
Successfully applied with terraform, and I was able to SSH to the new EC2 instance

